### PR TITLE
change the JwtProvider not to register as bean.

### DIFF
--- a/src/main/java/gugus/pleco/WebConfig.java
+++ b/src/main/java/gugus/pleco/WebConfig.java
@@ -1,5 +1,6 @@
 package gugus.pleco;
 
+import gugus.pleco.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -16,10 +17,6 @@ import gugus.pleco.jwt.JwtTokenProvider;
 @RequiredArgsConstructor
 public class WebConfig extends WebSecurityConfigurerAdapter {
 
-    private final JwtTokenProvider jwtTokenProvider;
-
-
-
     @Override
     @Bean
     public AuthenticationManager authenticationManagerBean() throws Exception{
@@ -29,6 +26,9 @@ public class WebConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+
+
+
         http.httpBasic().disable()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -37,6 +37,6 @@ public class WebConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/signup","/","/login","/duplicate","/profile").permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/gugus/pleco/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/gugus/pleco/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,9 @@
 package gugus.pleco.jwt;
 
+import gugus.pleco.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -11,10 +14,18 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilter {
-
-    private final JwtTokenProvider jwtTokenProvider;
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        /*
+        JwtProvider 의 경우 멤버 변수를 가지고 있으므로 bean 으로 등록하여 사용하는 것은 옳지 않다.
+        하지만 UserService 를 주입해줘야 하기 때문에  ApplicationContext 에서 가져와서 주입해준다.
+         */
+
+        AnnotationConfigApplicationContext apc = new AnnotationConfigApplicationContext();
+        UserService userService = (UserService) apc.getBean("userService");
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(userService);
+
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
         if(token!=null && jwtTokenProvider.validateToken(token)){
             Authentication authentication = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/gugus/pleco/jwt/JwtTokenProvider.java
+++ b/src/main/java/gugus/pleco/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package gugus.pleco.jwt;
 
+import gugus.pleco.service.UserService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -18,14 +19,13 @@ import java.util.Date;
 import java.util.List;
 
 @RequiredArgsConstructor
-@Component
 public class JwtTokenProvider {
 
     private String secretKey = "smuLookie99s";
 
     private Long validTokenTime = 30 *60* 60 *1000L;
 
-    private final UserDetailsService userDetailsService;
+    private final UserService userService;
 
     @PostConstruct
     protected void init() {
@@ -45,7 +45,7 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthentication(String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPk(token));
+        UserDetails userDetails = userService.loadUserByUsername(this.getUserPk(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 

--- a/src/main/java/gugus/pleco/service/UserEcoServiceImpl.java
+++ b/src/main/java/gugus/pleco/service/UserEcoServiceImpl.java
@@ -9,7 +9,6 @@ import gugus.pleco.excetion.NotExistPlee;
 import gugus.pleco.excetion.TimeDissatisfactionException;
 import gugus.pleco.repositroy.PleeRepository;
 import gugus.pleco.repositroy.UserEcoRepository;
-import gugus.pleco.repositroy.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,7 +27,6 @@ import java.util.List;
 public class UserEcoServiceImpl implements UserEcoService {
 
     private final UserEcoRepository userEcoRepository;
-    private final UserRepository userRepository;
     private final PleeRepository pleeRepository;
 
     @Log
@@ -41,7 +39,7 @@ public class UserEcoServiceImpl implements UserEcoService {
         LocalDateTime performTime = userEco.getPerformTime();
         // 현재 시간 nowTime 가져오기
         LocalDateTime nowTime = LocalDateTime.now();
-        //입력들어온 eco에 대하여 쿨타임 조회
+        //입력들어온 eco 에 대하여 쿨타임 조회
         Long coolTime = userEco.getEco().getCoolTime();
 
         // 수행할 수 있는지 계산
@@ -61,7 +59,7 @@ public class UserEcoServiceImpl implements UserEcoService {
         return plee;
     }
 
-    //UserEco 수행할 수 있을때까지 남은시간 알려주는 함수
+
     @Log
     @Override
     public LocalTime OneUserEcoTime(String email, String ecoName) {
@@ -73,38 +71,36 @@ public class UserEcoServiceImpl implements UserEcoService {
         LocalDateTime performTime = userEco.getPerformTime();
         // Eco 의 coolTime - (마지막 성공시간 - 현지새간) ->  UserEco 의 남은 coolTime 확인
         // 초를 시간으로 바꿈
-         return SecondChangeToTime(userEco.getEco().getCoolTime() - ChronoUnit.SECONDS.between(performTime, now));
+        return SecondChangeToTime(userEco.getEco().getCoolTime() - ChronoUnit.SECONDS.between(performTime, now));
 
     }
+    @Override
+    @Log
+    public List<UserEco> findAll(String email) {
+        return userEcoRepository.findByUsername(email);
+    }
 
-
-    // UserEco들에 관하여 실행 가능한 여부를 알려주는 로직
     @Log
     @Override
     public List<UserEcoListDto> UserEcoStatus(String email) {
         log.info("id: {}, location: {}", email, "UserEcoServiceImpl.UserEcoStatus");
         //현재 시간
         LocalDateTime now = LocalDateTime.now();
-        //UserEco를 user_eco_id순으로 정렬
+        //UserEco 를 user_eco_id순 으로 정렬
         List<UserEco> userEcoList = userEcoRepository.findByUsername(email);
-        //dto를 담기위해 선언
+        //dto 를 담기위해 선언
         List<UserEcoListDto> userEcoListDtos = new ArrayList<>();
 
         for(UserEco userEco: userEcoList){
-            //마지막 수행 시간과 현재시간을 비교하여 cooltime보다 크다면 possible 작다면 impossible
+            //마지막 수행 시간과 현재시간을 비교하여 cooltime 보다 크다면 possible 작다면 impossible
             String status = checkStatus(userEco.getPerformTime(), now, userEco.getEco().getCoolTime());
-            // 반환을 위한 DTO 변환 dto클래스는 controller/dto 패키지에 있음
+            // 반환을 위한 DTO 변환 dto 클래스는 controller/dto 패키지에 있음
             userEcoListDtos.add(new UserEcoListDto(userEco.getEco().getEcoName()
                     ,SecondChangeToTime(userEco.getEco().getCoolTime())
                     ,status));
         }
         log.info("id: {}, location: {}, status: {}", email, "UserEcoServiceImpl.UserEcoStatus","Complete");
         return userEcoListDtos;
-    }
-
-    @Override
-    public List<UserEco> findAll(String email) {
-        return userEcoRepository.findByUsername(email);
     }
 
     private String checkStatus(LocalDateTime performTime, LocalDateTime nowTime, Long coolTime){
@@ -120,7 +116,6 @@ public class UserEcoServiceImpl implements UserEcoService {
     private LocalTime SecondChangeToTime(Long second){
         if(second<=0){
             return LocalTime.of(0,0,0,0);
-
         }
         LocalTime localTime = LocalTime.of(second.intValue()/3600,(second.intValue()%3600)/60,second.intValue()%60,0);
         return localTime;
@@ -134,6 +129,4 @@ public class UserEcoServiceImpl implements UserEcoService {
             throw new TimeDissatisfactionException("아직 미션을 할 수 있는 시간이 아닙니다.");
         }
     }
-
-
 }


### PR DESCRIPTION

JwtProvider를 bean으로 등록하여 사용했었는데 해당 class는 멤버 변수를 가지고 있으므로 동시성 이슈가 나올 수 있다. 따라서 

JwtProvider가 필요할 때 생성하여 사용한다. 

JwtProvider는 UserService bean을 필요로 하므로 ApplicatipnContext에서 UserService bean을 찾아 주입해준다. 